### PR TITLE
Changed listGames from GET to POST

### DIFF
--- a/service/Routes.go
+++ b/service/Routes.go
@@ -49,7 +49,7 @@ var routes = Routes{
 	},
 	Route{
 		"List_Games",
-		"GET",
+		"POST",
 		"/listGames",
 		ListGames,
 	},


### PR DESCRIPTION
Although it is supported by RFC guidelines, Angular doesn't let me send a body like `{ "fields": [] }` with a GET request. I can only send bodies with POST/PUT requests. I've changed the `/listGames` route to accept POST requests as a temporary fix. 

Could you merge this for the time being and refactor to accept GET requests with url parameter values instead? 

Ex: `/listGames?fields=...`